### PR TITLE
fix truncating config description in gui

### DIFF
--- a/utils/Config.js
+++ b/utils/Config.js
@@ -20,6 +20,8 @@ const applyChanges = (/** @type {Settings} */setting) => {
     gui.background.width = setting.settings.width
     gui.background.height = setting.settings.height
 
+    gui.descriptionElement.textWrap.enabled = false
+
     // Apply changes
     setting.apply()
 }


### PR DESCRIPTION
Currently all mod option descriptions are truncated after 2 rows. This PR fixes this by removing the text limit.

<img width="668" height="90" alt="image" src="https://github.com/user-attachments/assets/9ee0bb7c-924e-4372-b2b1-4a18abd4fd46" />

---

This is default behaviour in Amaterasu. With it disabled the entire description is shown.

<img width="683" height="273" alt="image" src="https://github.com/user-attachments/assets/9fe6f336-6316-4760-96b8-e877ef332911" />